### PR TITLE
Hidden files filter improvement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,6 @@ var f = {is : '=<[^\\/^]>=', banner: function(){
   log(' |  | |  |  |  |  \\ | _/\\_ '.blue, 'v'+version );
 }};
 
-
-
 var files = require('fs').readdirSync(__dirname);
 
 //remove self
@@ -19,3 +17,18 @@ files.forEach(function(file) {
 });
 
 module.exports = f;
+
+/* >> hidden files filter proposition <<
+var fs = require('fs'), junk = require('junk');
+
+fs.readdir(__dirname, function (err, file) {
+  var files = file.filter(junk.not);
+  
+  log("Loading Core Matrix Files");
+  
+  files.forEach(function(file) {
+    log('Loading... '.grey, file);
+    f[file] = require('./' + file);
+  });
+});
+*/


### PR DESCRIPTION
I know what the [doc](https://nodejs.org/api/fs.html#fs_fs_readdirsync_path_options) says about `fs.readdirSync()` but it don't fully filter hidden files (in my case `.AppleDouble` (auto generated by netatalk)) causing error

Code proposition with junk package or with `fs.readdir()` and RegEx [here](http://stackoverflow.com/questions/18973655/how-to-ingnore-hidden-files-in-fs-readdir-result)