### PR TITLE
Don't crash if app folder was removed before starting it

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,7 +295,7 @@ var msg = [];
                   id: id
                 }, function(err){
                   //cb(err);
-                  console.log('Local app update failed ', err);
+                  if (err) console.log('Local app update failed ', err);
                 });
               }
             })

--- a/lib/device/heartbeat.js
+++ b/lib/device/heartbeat.js
@@ -30,7 +30,7 @@ module.exports = {
 
     _.each(Matrix.activeApplications, function(app){
 
-      debug('activeApp->', app.name, app.config.sensors, app.config.services )
+      debug('activeApp->', app.name, app.config.sensors || '', app.config.services || '' )
       // debug('activeApp->', app.name )
 
       // disable policy for now until deploy is good

--- a/lib/service/manager.js
+++ b/lib/service/manager.js
@@ -229,6 +229,10 @@ function startApp(name, cb) {
           app.appName = name;
           cb();
         } else {
+          console.log('App '.red + name.yellow + ' local folder wasn\'t found!'.red);
+          Matrix.activeApplications = _.reject(Matrix.activeApplications, function(app) { //Remove from active applications
+            return (app.name === name);
+          });
           cb(new Error('The unexpected was expected, please avoid deleting app folders without letting MOS know'));
         }
 
@@ -360,7 +364,7 @@ function startApp(name, cb) {
   ], function(err){
     if (err) {
       app.setRuntimeStatus('error');
-      return console.log(err.red);
+      return err.hasOwnProperty('message') ? console.log(err.message.red) : console.log(err); 
     }
     console.log('==== Application %s started! ==== '.yellow, name);
 

--- a/lib/service/manager.js
+++ b/lib/service/manager.js
@@ -192,8 +192,8 @@ function startApp(name, cb) {
     return;
   }
 
-
   var app;
+  var pathToApp = './apps/' + name + '.matrix';
 
   async.series([
     function makeAppInstance(cb){
@@ -209,24 +209,30 @@ function startApp(name, cb) {
       debug(app.config);
       debug('=== %s policy === vvvv'.blue, name, app.id )
       debug(app.policy);
+      
+      fs.access(pathToApp, function(err) { //Check for app folder existance, expect the unexpected (╯°□°）╯︵ ┻━┻
+        if (!err) {
+          fs.writeFileSync(pathToApp + '/config.json', JSON.stringify(app.config));
+          app.process = require('child_process').fork(pathToApp + '/index.js', [], {
+            // pipes logs to parent below
+            silent: true,
+            // make available to app environment
+            env: _.extend({
+              // to route debug to stdout as to not trigger error quit
+              DEBUG_FD: 1,
+            }, app.config.settings)
+          });
 
-      fs.writeFileSync('./apps/' + name + '.matrix/config.json', JSON.stringify(app.config));
+          // keep track of event listeners
+          app.process.handlers = {};
+          app.pid = app.process.pid;
+          app.appName = name;
+          cb();
+        } else {
+          cb(new Error('The unexpected was expected, please avoid deleting app folders without letting MOS know'));
+        }
 
-      app.process = require('child_process').fork('./apps/' + name + '.matrix/index.js', [], {
-        // pipes logs to parent below
-        silent: true,
-        // make available to app environment
-        env: _.extend({
-          // to route debug to stdout as to not trigger error quit
-          DEBUG_FD: 1,
-        }, app.config.settings)
       });
-
-      // keep track of event listeners
-      app.process.handlers = {};
-      app.pid = app.process.pid;
-      app.appName = name;
-      cb();
     },
 
 
@@ -354,7 +360,7 @@ function startApp(name, cb) {
   ], function(err){
     if (err) {
       app.setRuntimeStatus('error');
-      return console.log(err);
+      return console.log(err.red);
     }
     console.log('==== Application %s started! ==== '.yellow, name);
 


### PR DESCRIPTION
If MOS had already started, an app folder was removed and then you start it from a client MOS was crashing. This doesn't happen anymore

Also:

- Local app install failed message should only be printed if there was actually an error
- On heartbeat, don't print sensors nor services if there are none to print (was printing undefined)