### PR TITLE
Don't count apps as activeApps until initialization succeeds

### DIFF
--- a/lib/service/manager.js
+++ b/lib/service/manager.js
@@ -198,12 +198,10 @@ function startApp(name, cb) {
     function makeAppInstance(cb){
       debug('creating instance:'.blue, name);
       app = new Matrix.service.application.Application(name, cb);
-
-      // keep track of applications, route reply messages
-      Matrix.activeApplications.push(app);
     },
     function startAppProcess(cb){
-
+      // keep track of applications, route reply messages
+      Matrix.activeApplications.push(app);
       debug('=== %s config === vvvv'.blue, name, app.id )
       debug(app.config);
       debug('=== %s policy === vvvv'.blue, name, app.id )
@@ -368,7 +366,8 @@ function startApp(name, cb) {
   ], function(err){
     if (err) {
       app.setRuntimeStatus('error');
-      return err.hasOwnProperty('message') ? console.log(err.message.red) : console.log(err);
+      err.hasOwnProperty('message') ? console.log(err.message.red) : console.log(err);
+      return console.log('Unable to start application, please make sure MOS and the Application are up to date.'.yellow);
     }
     console.log('==== Application %s started! ==== '.yellow, name);
 


### PR DESCRIPTION
Apps that failed during initialization where still being added to activeApplications, this happens no more.