### PR TITLE
Multiple app restarts on deploy fixed

### DIFF
--- a/lib/service/manager.js
+++ b/lib/service/manager.js
@@ -272,8 +272,9 @@ function startApp(name, cb) {
     function setupLocalAppManagement(cb){
 
       // when config changes, restart app
-      Matrix.service.firebase.app.watchConfig(app.appId, function(){
-        restartApp( name );
+      Matrix.service.firebase.app.watchConfig(app.appId, function () {
+        console.log('App configuration changed');
+        //restartApp( name ); //Removed this because it was causing 1-4 restarts on app deployment
       })
 
       // for restarting active apps //TODO: Not complete
@@ -391,13 +392,16 @@ function startApp(name, cb) {
 
 function stopApp(id, cb) {
   var error;
+  var appStopped = false;
   log('Stopping'.red, id);
 
-  if (id === 'all-applications'){
+  if (id === 'all-applications') {
     killAllApps(cb);
   } else if (parseInt(id) === id) {
+    debug('Killing process #' + id);
     cb(require('child_process').exec('kill ' + id));
   } else {
+    debug('Killing process for app ' + id);
     Matrix.events.removeAllListeners('app-' + id + '-message');
     // log('stop %s', id);
     // handle local variable
@@ -408,6 +412,7 @@ function stopApp(id, cb) {
 
     //If the application was already started
     if (!_.isUndefined(applicationInstance)) {
+      debug('Application ' + id + ' is running (' + applicationInstance.pid + ')');
       applicationInstance.setRuntimeStatus('inactive');
 
       // heads will roll o/ |o| \8/
@@ -416,7 +421,9 @@ function stopApp(id, cb) {
       Matrix.activeApplications = _.reject(Matrix.activeApplications, function(p) {
         return (p.name === id);
       });
+      appStopped = true; //TODO Maybe actually make sure the process is killed?
     } else {
+      debug('Application ' + id + ' isn\'t running');
       console.warn('Application instance not available', id);
       error = new Error('Application ' + id + ' wasn\'t started');
     }
@@ -426,7 +433,7 @@ function stopApp(id, cb) {
       return (p.name === id);
     });
 
-    if (_.isFunction(cb)) cb();
+    if (_.isFunction(cb)) cb(error, appStopped);
   }
 }
 


### PR DESCRIPTION
On deploy, if changes were detected in the app config multiple app restarts were issues, apparently the last restart's stop overlapped with the deploy stop, this fixes it.