### PR TITLE
Fix wrong temperature readings, average from 2 sensors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.11.1]
 ### Removed
 - Deprecated applicationConfigs on register
 
 ### Added
 - Emit app-config to mxss on app start
+### Changed
+- Reenabled service.then
 
 ## [0.11.0]
 ### Changed

--- a/lib/device/drivers/temperature.js
+++ b/lib/device/drivers/temperature.js
@@ -11,7 +11,11 @@ module.exports = {
     matrixMalosBuilder = protoBuilder.build('matrix_malos')
   },
   read: function(buffer){
-    return { value: new matrixMalosBuilder.Humidity.decode(buffer).temperature }
+    var tempFromPressure = new matrixMalosBuilder.Pressure.decode(buffer).temperature;
+    var tempFromHumidity = new matrixMalosBuilder.Humidity.decode(buffer).temperature_raw;
+    var avgTemperature = (tempFromPressure + tempFromHumidity) / 2;
+    
+    return { value: avgTemperature }
   },
   prepare: function(options, cb){
     if (_.isFunction(options)){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-os",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Portal to device layer for AdMobilize Matrix devices. Includes global component, npm install -g matrix-cli",
   "main": "app.js",
   "repository": "http://github.com/matrix-io/matrix-os",


### PR DESCRIPTION
I noticed temperature readings for the matrix-os were wrong when I tried to use them for the hackathon.
Tried reading the Humidity sensor with the HAL and with MALOS and both returned the *correct* value.
Just edited the matrix-os files to check whether the temperature from Pressure sensor was OK and it was just fine (about 35C). Then, I realized in protobuf definition file for temperature you have the 'temperature_raw' variable which surprisingly or not returns the correct value for the temperature sensor.

I corrected that and did a bit more: evaluated the temperature as being the average between both sensors that inform temperature data: Humidity and Pressure.


