### PR TITLE
debug() is causing an error in the OS

### DIFF
--- a/apps/lib/gpio.js
+++ b/apps/lib/gpio.js
@@ -60,7 +60,7 @@ module.exports = {
   },
 
   write: function (pin, value, cb) {
-    debug("PIN WRITE: ", pin, value);
+    console.log("PIN WRITE: ", pin, value);
     pinWriteHandlers[pin] = cb;
     process.send({
       type: 'gpio-write',


### PR DESCRIPTION
@eighteyes 

Error Message:
No GPIO Component Available for Ping
(servoTesting)err /home/pi/matrix-os/apps/lib/gpio.js:63
    debug("PIN WRITE: ", pin, value);
    ^

ReferenceError: debug is not defined
    at Object.write (/home/pi/matrix-os/apps/lib/gpio.js:63:5)
    at Timeout._repeat (/home/pi/matrix-os/apps/servoTesting.matrix/app.js:10:14)
    at Timeout.wrapper [as _onTimeout] (timers.js:425:11)
    at tryOnTimeout (timers.js:232:11)
    at Timer.listOnTimeout (timers.js:202:5)