### PR TITLE
Jc/create storage onstart

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.13.0]
+### Changed
+- Updated recog code for es6's new attitude towards constructors
+- Upgrade node to 6 in travis tests and package.json
+
+### Remove
+- Remove auto upgrade code. It stunk.
+
+### Added
+- MOS as as service in debian
+
+### Fixed
+- network typo
+
 ## [0.12.0]
 ### Changed 
 - Fixed network issues

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.14.1]
+### Fixed
+- Can now stop apps without services
+
 ## [0.14.0]
 ### Changed
 - Force a single service to be utilized at a time

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.14.0]
+### Changed
+- Force a single service to be utilized at a time
+  
+### Fixed
+- Deploy and restart apps now work
+- Stop apps from launching if config fails validation
+
 ## [0.13.0]
 ### Changed
 - Updated recog code for es6's new attitude towards constructors

--- a/apps/matrix.js
+++ b/apps/matrix.js
@@ -23,6 +23,7 @@ error = function() {
 };
 
 var appName = '';
+var assetPath = '';
 
 var storeManager = {
   get: getStore,
@@ -57,7 +58,6 @@ function deleteStore(key, cb) {
 
 var fileManager = {
   save: function(url, filename, cb) {
-    var assetPath = __dirname + '/' + appName + '.matrix/storage/';
     request.get(url, function(err, resp, body) {
       if (err) error(err);
       try {
@@ -73,16 +73,13 @@ var fileManager = {
     // are we doing this? yes, for streaming media
   },
   remove: function(filename, cb) {
-    var assetPath = __dirname + '/' + appName + '.matrix/storage/';
     fs.unlink(assetPath + filename, cb);
   },
   load: function(filename, cb) {
-    var assetPath = __dirname + '/' + appName + '.matrix/storage/';
     //todo: handle async and sync based on usage
     fs.readFile(assetPath + filename, cb);
   },
   list: function(cb) {
-    var assetPath = __dirname + '/' + appName + '.matrix/storage/';
     fs.readdir(assetPath, function(err, files) {
       if (err) error(err);
       cb(null, files);
@@ -298,6 +295,13 @@ var Matrix = {
       Matrix[k] = Matrix.config.settings[k];
     });
 
+		// check if the app has a storage directory
+    assetPath = __dirname + '/' + appName + '.matrix/storage/';
+		try{
+			fs.accessSync(assetPath);
+		}catch(e){
+			fs.mkdirSync(assetPath);
+		}
 
     // console.log('setup generic listener');
     // generic message handlers

--- a/apps/matrix.js
+++ b/apps/matrix.js
@@ -301,7 +301,7 @@ var Matrix = {
 			fs.accessSync(assetPath);
 		}catch(e){
 			fs.mkdirSync(assetPath);
-		}
+	  }
 
     // console.log('setup generic listener');
     // generic message handlers

--- a/lib/service/manager.js
+++ b/lib/service/manager.js
@@ -500,7 +500,7 @@ function startApp(name, cb) {
         });
 
         //Remove unused active services
-        if ( Object.keys(app.services).length > 0 ){
+        if ( !_.isUndefined(app.services) && Object.keys(app.services).length > 0 ){
           
           Matrix.activeServices = _.reject(Matrix.activeServices, function(s){
             // find app service names

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-os",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Portal to device layer for AdMobilize Matrix devices. Includes global component, npm install -g matrix-cli",
   "main": "app.js",
   "repository": "http://github.com/matrix-io/matrix-os",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-os",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Portal to device layer for AdMobilize Matrix devices. Includes global component, npm install -g matrix-cli",
   "main": "app.js",
   "repository": "http://github.com/matrix-io/matrix-os",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-os",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Portal to device layer for AdMobilize Matrix devices. Includes global component, npm install -g matrix-cli",
   "main": "app.js",
   "repository": "http://github.com/matrix-io/matrix-os",


### PR DESCRIPTION
Set `assetPath` as a global and apps now check for storage on startup. 
Apologies for the ugly indents, it's likely due to misconfigured vim.