### PR TITLE
[MX-335] add strictPhraseMatch option to matrix.listen

### DIFF
--- a/apps/lib/service.js
+++ b/apps/lib/service.js
@@ -63,7 +63,7 @@ var service = function(name, options) {
         return console.error('Invalid or Undefined Wake Word', self.wakeword, 'looking for', self.service.wakeword)
       }
 
-      if ( !_.isUndefined(self.service.strictPhraseMatch) && self.service.strictPhraseMatch === true) {
+      if ( _.isUndefined(self.service.strictPhraseMatch) || self.service.strictPhraseMatch === true) {
         self.strictPhraseMatch = true;
 
         self.phrases = self.service.phrases;

--- a/apps/lib/service.js
+++ b/apps/lib/service.js
@@ -65,6 +65,7 @@ var service = function(name, options) {
 
       if ( !_.isUndefined(self.service.strictPhraseMatch) && self.service.strictPhraseMatch === true) {
         self.strictPhraseMatch = true;
+
         self.phrases = self.service.phrases;
 
         if ( _.isUndefined(self.phrases) || self.phrases.length === 0 ){
@@ -92,7 +93,7 @@ var service = function(name, options) {
     },
 
     then: function(cb){
-      var phraseRegex = self.stricPhraseMatch ? new RegExp(self.phrases.join('|'),'i') : new RegExp('.*?', 'i');
+      var phraseRegex = self.strictPhraseMatch ? new RegExp(self.phrases.join('|'),'i') : new RegExp('.*?', 'i');
       process.on('message', function(data) {
         console.log('VOICE SERVICE >> ', data, phraseRegex)
         if (data.eventType === 'service-emit' &&

--- a/apps/lib/service.js
+++ b/apps/lib/service.js
@@ -63,10 +63,15 @@ var service = function(name, options) {
         return console.error('Invalid or Undefined Wake Word', self.wakeword, 'looking for', self.service.wakeword)
       }
 
-      self.phrases = self.service.phrases;
+      if ( !_.isUndefined(self.service.strictPhraseMatch) && self.service.strictPhraseMatch === true) {
+        self.strictPhraseMatch = true;
+        self.phrases = self.service.phrases;
 
-      if ( _.isUndefined(self.phrases) || self.phrases.length === 0 ){
-        return console.error('No Phrases defined in service configuration', service)
+        if ( _.isUndefined(self.phrases) || self.phrases.length === 0 ){
+          return console.error('No Phrases defined in service configuration', service)
+        }
+      } else {
+        self.strictPhraseMatch = false;
       }
       
       // no type here
@@ -87,7 +92,7 @@ var service = function(name, options) {
     },
 
     then: function(cb){
-      var phraseRegex = new RegExp(self.phrases.join('|'),'i');
+      var phraseRegex = self.stricPhraseMatch ? new RegExp(self.phrases.join('|'),'i') : new RegExp('.*?', 'i');
       process.on('message', function(data) {
         console.log('VOICE SERVICE >> ', data, phraseRegex)
         if (data.eventType === 'service-emit' &&

--- a/lib/device/drivers/voice.js
+++ b/lib/device/drivers/voice.js
@@ -66,8 +66,8 @@ module.exports = {
 
     let voiceConfigProto = new matrixMalosBuilder.WakeWordParams;
     voiceConfigProto.set_wake_word(wakeword.toUpperCase());
-    voiceConfigProto.set_lm_path('/home/pi/assets/6854.lm');
-    voiceConfigProto.set_dic_path('/home/pi/assets/6854.dic');
+    voiceConfigProto.set_lm_path('/home/pi/assets/voice.lm');
+    voiceConfigProto.set_dic_path('/home/pi/assets/voice.dic');
 
     if (_.has(config.options, 'channel')) {
       if (


### PR DESCRIPTION
Changelog:

- Add option to disable **Strict Phrase Match** on apps config file.
- Change **.LM** and **.DIC** filename to a generic form so we don't need to change the name on the MOS code every time we generate new dictionaries.